### PR TITLE
fix: add missing case for unscoped name

### DIFF
--- a/CxxDemangler/Parsers/UnscopedName.cs
+++ b/CxxDemangler/Parsers/UnscopedName.cs
@@ -21,6 +21,19 @@
                 return new Std(name);
             }
 
+            if (context.Parser.VerifyString("L"))
+            {
+                IParsingResultExtended name = UnqualifiedName.Parse(context);
+
+                if (name == null)
+                {
+                    context.Rewind(rewind);
+                    return null;
+                }
+
+                return name;
+            }
+
             return UnqualifiedName.Parse(context);
         }
 

--- a/Tests/Parsing/UnscopedName.cs
+++ b/Tests/Parsing/UnscopedName.cs
@@ -21,11 +21,19 @@ namespace CxxDemangler.Tests.Parsing
         }
 
         [TestMethod]
+        public void UnscopedNameFixedLength()
+        {
+            Verify("L10helloworld...",
+                new Parsers.SourceName.Identifier("helloworld"));
+        }
+
+        [TestMethod]
         public void UnscopedNameFailures()
         {
             Assert.IsNull(Parse("St..."));
             Assert.IsNull(Parse("..."));
             Assert.IsNull(Parse(""));
+            Assert.IsNull(Parse("L..."));
         }
 
         internal override IParsingResult Parse(ParsingContext context)


### PR DESCRIPTION
example:
_ZL17android_app_entryPv => android_app_entry(void*)